### PR TITLE
Refactor createUser with fluent builder

### DIFF
--- a/src/application/combinators/fluent.ts
+++ b/src/application/combinators/fluent.ts
@@ -1,0 +1,25 @@
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as RTE from 'fp-ts/lib/ReaderTaskEither';
+
+export const fx = {
+  async:
+    <I = void, O = void, Err = unknown>() => ({
+      has:
+        <D>() =>
+        (
+          impl: (deps: D, input: I) => TE.TaskEither<Err, O>,
+        ) =>
+        (input: I): RTE.ReaderTaskEither<D, Err, O> =>
+          (deps) => impl(deps, input),
+    }),
+  sync:
+    <I = void, O = void>() => ({
+      has:
+        <D>() =>
+        (
+          impl: (deps: D, input: I) => O,
+        ) =>
+        (input: I): RTE.ReaderTaskEither<D, never, O> =>
+          (deps) => TE.right(impl(deps, input)),
+    }),
+} as const;

--- a/src/application/combinators/index.ts
+++ b/src/application/combinators/index.ts
@@ -1,1 +1,2 @@
 export * from './effects';
+export * from './fluent';

--- a/src/application/usecases/createUser.ts
+++ b/src/application/usecases/createUser.ts
@@ -1,57 +1,64 @@
 import * as TE from 'fp-ts/lib/TaskEither';
 import * as RTE from 'fp-ts/lib/ReaderTaskEither';
 import { pipe } from 'fp-ts/lib/function';
+
 import { User } from '../../domain/user';
 import { DomainError } from '../../domain/errors';
 import { UserRepository, EmailService, Logger } from '../ports';
-import { validateCreateUserInput, CreateUserInput } from '../../domain/userValidation';
+import { CreateUserInput, validateCreateUserInput } from '../../domain/userValidation';
 import { createUserEntity } from '../../domain/userFactory';
-import { createEffect } from '../combinators';
+import { fx } from '../combinators/fluent';
 
-export type CreateUserDeps = {
-  userRepository: UserRepository;
-  emailService: EmailService;
-  logger: Logger;
-};
+export type LoggerDep = { readonly logger: Logger };
+export type UserRepositoryDep = { readonly userRepository: UserRepository };
+export type EmailServiceDep = { readonly emailService: EmailService };
 
-const effects = createEffect<CreateUserDeps, DomainError>();
+const checkEmailNotExists =
+  fx.async<CreateUserInput>().has<UserRepositoryDep>()(({ userRepository }, input) =>
+    pipe(
+      userRepository.findByEmail(input.email),
+      TE.matchE(
+        (err) => (err._tag === 'UserNotFound' ? TE.right<void>(undefined) : TE.left(err)),
+        () =>
+          TE.left<DomainError>({
+            _tag: 'ValidationError',
+            errors: [{ field: 'email', message: 'Email already exists' }],
+          }),
+      ),
+    ),
+  );
+
+const createAndSaveUser =
+  fx.async<CreateUserInput, User>().has<UserRepositoryDep & LoggerDep>()(
+    ({ userRepository, logger }, input) =>
+      pipe(
+        TE.fromEither(createUserEntity(input)),
+        TE.tap((user) => TE.fromIO(() => logger.info('Creating user entity', { userId: user.id }))),
+        TE.flatMap((user) => userRepository.save(user)),
+      ),
+  );
+
+const sendWelcomeEmail =
+  fx.async<User>().has<EmailServiceDep & LoggerDep>()(({ emailService, logger }, user) =>
+    pipe(
+      emailService.sendWelcomeEmail(user),
+      TE.orElse((err) => {
+        logger.error('Failed to send welcome email', new Error(JSON.stringify(err)), { userId: user.id });
+        return TE.left(err);
+      }),
+    ),
+  );
+
+const logUserCreated =
+  fx.sync<User>().has<LoggerDep>()(({ logger }, user) =>
+    logger.info('User created successfully', { userId: user.id }),
+  );
 
 export const createUser = (input: CreateUserInput) =>
   pipe(
     RTE.fromEither(validateCreateUserInput(input)),
-    RTE.tap(checkEmailNotExists),
-    RTE.flatMap(createAndSaveUser),
-    RTE.tap(effects.sync(({ logger }, user) => logger.info('User created successfully', { userId: user.id }))),
-    RTE.tap(sendWelcomeEmail),
+    RTE.chainW(checkEmailNotExists(input)),
+    RTE.chainW(createAndSaveUser(input)),
+    RTE.tapW(logUserCreated(undefined)),
+    RTE.tapW(sendWelcomeEmail),
   );
-
-const checkEmailNotExists = effects.async<CreateUserInput>(({ userRepository }, validInput) =>
-  pipe(
-    userRepository.findByEmail(validInput.email),
-    TE.flatMap(() =>
-      TE.left<DomainError>({
-        _tag: 'ValidationError',
-        errors: [{ field: 'email', message: 'Email already exists' }],
-      }),
-    ),
-    TE.orElse((error) => (error._tag === 'UserNotFound' ? TE.right(undefined) : TE.left(error))),
-  ),
-);
-
-const createAndSaveUser = effects.asyncTransform<CreateUserInput, User>(({ userRepository, logger }, validInput) =>
-  pipe(
-    TE.fromEither(createUserEntity(validInput)),
-    TE.tap((user) => TE.fromIO(() => logger.info('Creating user entity', { userId: user.id }))),
-    TE.flatMap((user) => userRepository.save(user)),
-  ),
-);
-
-const sendWelcomeEmail = effects.async<User>(({ emailService, logger }, user) =>
-  pipe(
-    emailService.sendWelcomeEmail(user),
-    TE.orElse((error) => {
-      logger.error('Failed to send welcome email', new Error(JSON.stringify(error)), { userId: user.id });
-      return TE.left(error);
-    }),
-  ),
-);


### PR DESCRIPTION
## Summary
- add `fx` fluent combinator builder
- refactor `createUser` to use the new builder
- export `fx` from combinators index

## Testing
- `pnpm exec jest` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bc7496d5c83278623d269a92ef716